### PR TITLE
2 - Feature

### DIFF
--- a/App/Monitor/Monitor/ViewModels/TableViewHandler.swift
+++ b/App/Monitor/Monitor/ViewModels/TableViewHandler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Combine
 
 /// Struct that holds the minimum data that can be rendered on a UITableView using cells with the `UITableViewCell.CellStyle.subtitle` style.
 struct Entity {
@@ -11,10 +12,16 @@ struct Entity {
 final class TableViewHandler: NSObject {
     weak var tableView: UITableView?
     
+    /// Published property with no value to indicate that the table just reloaded it's data
+    @Published var reloaded: Void = ()
+    /// Published selected index
+    @Published var selectedIndex: IndexPath? = nil
+    
     let reuseIdentifier = "cell"
     var entities = [Entity]() {
         didSet {
             self.tableView?.reloadData()
+            self.reloaded = ()
         }
     }
     
@@ -22,6 +29,7 @@ final class TableViewHandler: NSObject {
         self.tableView = tableView
         super.init()
         tableView.dataSource = self
+        tableView.delegate = self
     }
 }
 
@@ -38,5 +46,19 @@ extension TableViewHandler: UITableViewDataSource {
         cell.detailTextLabel?.text = entities[indexPath.row].subtitle
         
         return cell
+    }
+}
+
+/// Conformance to UITableViewDelegate
+extension TableViewHandler: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // We simply store the selected index path
+        self.selectedIndex = indexPath
+    }
+    
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        // As we currently don't support multiple selection is ok to assume our currently selected index
+        // was deselected
+        self.selectedIndex = nil
     }
 }


### PR DESCRIPTION
This is an example on how to fix the second exercise. The idea is to slowly migrate existing UIKit that by nature is more imperative to something more declarative without refactoring the whole app.

In this example we are modifying the ViewModel `TableViewHandler` and expose some properties to be consumed by `MainViewController.swift`.

---

In programming there several ways to solve a problem. The solution examples in this repository are all focused on simplicity and brevity, there are "_better_" alternative ways to achieve the same result.

The code is commented in an attempt to make it more understandable.

---

Feel free to reach for me [on twitter](https://twitter.com/dev_jac) if you have questions, comments or you would like to discuss a portion of the code.
 You can also fork and send back pull request with your proposed solutions if you would like to discuss it over the PR or in private.